### PR TITLE
Update Docker Compose Usage Guide

### DIFF
--- a/docs/hosting/_includes/docker/_docker-compose-usage.mdx
+++ b/docs/hosting/_includes/docker/_docker-compose-usage.mdx
@@ -82,7 +82,7 @@ For more information on which environment variables are available on passbolt, p
   <>
     <pre className="prism-code language-bash">
       <code>
-        docker-compose -f docker-compose-{props.productName.toLowerCase()}.yaml
+        docker compose -f docker-compose-{props.productName.toLowerCase()}.yaml \
         exec passbolt su -m -c "/usr/share/php/passbolt/bin/cake \
         <br />
         passbolt register_user \


### PR DESCRIPTION
Corrected the Docker command in `_docker-compose-usage.mdx` to ensure accuracy and coherence in the Docker Compose usage guide, particularly regarding Passbolt registration within Docker environments. This pull request includes minor adjustments aimed at improving readability and adhering to best practices.