### PR TITLE
fix (P)ASSBOLT_PLUGINS_MFA_YUBIKEY_SECRETKEY typo

### DIFF
--- a/docs/admin/authentication/mfa/yubikey.mdx
+++ b/docs/admin/authentication/mfa/yubikey.mdx
@@ -85,7 +85,7 @@ If you are [using docker](/hosting/install/ce/docker/), you can set these enviro
 
 | Variable name | Description | Type |
 | --- | --- | --- |
-| ASSBOLT_PLUGINS_MFA_YUBIKEY_SECRETKEY | YubiCloud secret key | string |
+| PASSBOLT_PLUGINS_MFA_YUBIKEY_SECRETKEY | YubiCloud secret key | string |
 | PASSBOLT_PLUGINS_MFA_YUBIKEY_CLIENTID | YubiCloud client id | integer |
 
 ## Setup YubiKey as a user


### PR DESCRIPTION
on the yubikey configuration page there's a typo in a variable name:

![image](https://github.com/user-attachments/assets/bc88063d-8aab-4ce8-9a49-11a9ce73c9fc)

thanks for the chuckle ;)