### PR TITLE
Fix typo in `from-docker.mdx` file 

### DIFF
--- a/docs/hosting/backup/from-docker.mdx
+++ b/docs/hosting/backup/from-docker.mdx
@@ -27,7 +27,7 @@ There are also several elements you need to backup:
 We assume here Passbolt container is named __passbolt-container__ and MariaDB container __database-container__. Please replace these names with your own. You can use docker ps for this.
 
 :::warning[Please Note]
-Many docker users use __-ti__, __-it__ or __-t -i__ arguments to execute commands on docker containers. To get reliable backups on docker, please use only __-i__, as __-t__ will create a pseudo-tty and make your backup files unusuable.
+Many docker users use __-ti__, __-it__ or __-t -i__ arguments to execute commands on docker containers. To get reliable backups on docker, please use only __-i__, as __-t__ will create a pseudo-tty and make your backup files unusable.
 :::
 
 ### 1. The database


### PR DESCRIPTION
Change `unusuable` to `unusable`

![image](https://github.com/user-attachments/assets/fbb95ce0-6ae9-43a9-ab5c-063cb3bb5344)
