### PR TITLE
change run to exec, elevate 440 to 550, add example test

### DIFF
--- a/docs/hosting/_includes/migrate/docker/_prerequisites.mdx
+++ b/docs/hosting/_includes/migrate/docker/_prerequisites.mdx
@@ -103,10 +103,15 @@ docker cp serverkey.asc your-passbolt-container:/etc/passbolt/gpg/serverkey.asc
 Then set correct rights:
 
 ```bash
-docker exec -it your-passbolt-container chown www-data:www-data /etc/passbolt/gpg/serverkey.asc
-docker exec -it your-passbolt-container chown www-data:www-data /etc/passbolt/gpg/serverkey_private.asc
-docker exec -it your-passbolt-container chmod 440 /etc/passbolt/gpg/serverkey.asc
-docker exec -it your-passbolt-container chmod 440 /etc/passbolt/gpg/serverkey_private.asc
+docker run --rm your-passbolt-container chown -R www-data:www-data /etc/passbolt/gpg
+docker run --rm your-passbolt-container chmod -R 550 /etc/passbolt/gpg
+```
+
+To test if user `www-data` can read the files:
+
+```bash
+docker run --rm your-passbolt-container -u www-data cat /etc/passbolt/gpg/serverkey.asc
+docker run --rm your-passbolt-container -u www-data cat /etc/passbolt/gpg/serverkey_private.asc
 ```
 
 ### That's it


### PR DESCRIPTION
it's impossible to do `docker exec` when the passbolt container isn't running, and the passbolt container won't run if it can't read the gpg keys, as it keeps restarting. Thus it's better to use `run --rm`

I just had an outage because 440 permissions don't allow passbolt to execute commands on the folder, and subsequently the files, which is why it kepth throwing permission errors and boot looping. With 440 `docker run --rm your-passbolt-container -u www-data cat /etc/passbolt/gpg/serverkey.asc` throws permission denied error.

the `-u www-data cat` would have been very useful to debugging this, so I think it's helpful enough to test if user can read the file before turning passbolt on.

I also changed the 4 direct file chown/chmods to use `-R` and apply to the folder too, because the folder also has to be owned and accessible to the `www-data user`.

after applying these, I could finally resume my deployment.