### PR TITLE
Add extra section briefly explaining editing of user access in groups

### DIFF
--- a/docs/admin/user-provisioning/manage-groups.mdx
+++ b/docs/admin/user-provisioning/manage-groups.mdx
@@ -17,3 +17,7 @@ group manager. No more, no less.
 
 It is possible for a group member to share a resource he owns in “read-only” mode with the group. Group manager
 doesn’t have extra-rights to edit resources ownership.
+
+## How do I add or edit users access in a group?
+
+Only group managers may edit group members. This can be done with a specific group where you have the group manager role via the settings button -> "Manage Users and Groups" -> 3 dots button on the group in the sidebar, then "Edit" to access the user sharing menu. Here you may edit access to the group for existing users, and add access for additional users by utilising the search function. Note that multiple group managers can be assigned.


### PR DESCRIPTION
Noticed details on how to actually change group members etc. is currently omitted from the website; welcome to commit changes to rephrase as necessary. As this page comes up fairly high in the google search results for "how do I add users to a group in passbolt" something should really exist on this page explaining as such.