### PR TITLE
Add a missing space in docker troubleshoot command

### DIFF
--- a/docs/hosting/troubleshooting/docker.mdx
+++ b/docs/hosting/troubleshooting/docker.mdx
@@ -34,7 +34,7 @@ Then to be able to launch some commands, you must retrieve `PASSBOLT_GPG_SERVER_
 
 <CodeBlock>
   {`export PASSBOLT_GPG_SERVER_KEY_FINGERPRINT="$(gpg \\
-  --home $GNUPGHOME\\
+  --home $GNUPGHOME \\
   --list-keys \\
   \${PASSBOLT_KEY_EMAIL:-passbolt@yourdomain.com} | \\
   grep -Ev "^(pub|sub|uid|^$)" | tr -d ' ')"`}


### PR DESCRIPTION
Because there is a missing space before the newline (which is escaped) when pasting the command the space is missing between `$GNUPGHOME` and `--list-keys`:
```
... gpg --home $GNUPGHOME--list-keys ...
```
the above command is interpreted leading to:
```
...
gpg: WARNING: no command supplied.  Trying to guess what you mean ...
...
```